### PR TITLE
Fix script tag definition in downloads docs

### DIFF
--- a/public_html/download.html
+++ b/public_html/download.html
@@ -95,7 +95,7 @@
                 </p>
                 <pre class=""><code>
                     &lt;link rel="stylesheet" href="https://cdn.metroui.org.ua/v4/css/metro-all.min.css"&gt;
-                    &lt;script href="https://cdn.metroui.org.ua/v4/js/metro.min.js"&gt;&lt;/script&gt;
+                    &lt;script src="https://cdn.metroui.org.ua/v4/js/metro.min.js"&gt;&lt;/script&gt;
                 </code></pre>
                 <p class="text-small">
                     * Metro CDN, provided for free by the folks at <a href="https://www.keycdn.com/">KeyCDN</a>


### PR DESCRIPTION
`<script>` tag requires `src` attribute, not `href`