### PR TITLE
Fix typos in grid docs

### DIFF
--- a/public_html/grid.html
+++ b/public_html/grid.html
@@ -211,8 +211,8 @@
                     <li>Content should be placed within columns, and only columns may be immediate children of rows.</li>
                     <li>Grid columns without a set width will automatically layout with equal widths. For example, four instances of <span class="tally">.cell-sm</span> will each automatically be <span class="tally">25%</span> wide for small breakpoints.</li>
                     <li>Column classes indicate the number of columns you’d like to use out of the possible 12 per row. So, if you want three equal-width columns, you can use <span class="tally">.cell-sm-4</span>.</li>
-                    <li>Column widths are set in percentallyes, so they’re always fluid and sized relative to their parent element.</li>
-                    <li>Columns have horizontal padding to create the gutters between individual columns, however, you can remove the margin from rows and padding from columns with <span class="tally">.no-gap</span> on the <span class="tally">.row</span> or on the <span class="tally">.grid</span> for all rows in grid.</li>
+                    <li>Column widths are set in percentiles, so they’re always fluid and sized relative to their parent element.</li>
+                    <li>Columns have horizontal padding to create the gutters between individual columns, however, you can remove the margin from rows and padding from columns with <span class="tally">.no-gap</span> on the <span class="tally">.row</span> or on the <span class="tally">.grid</span> for all rows in a grid.</li>
                     <li>There are five grid tiers, one for each <a href="#">responsive breakpoint</a>: small (sm), medium (md), large (lg), extra large (xl) and ultra large (xxl).</li>
                     <li>Grid tiers are based on minimum widths, meaning they apply to that one tier and all those above it (e.g., <span class="tally">.cell-md-4</span> applies to medium, large, extra large and ultra large devices).</li>
                     <li>You can use predefined grid classes for more semantic markup.</li>


### PR DESCRIPTION
percentallyes -> percentiles, and some minor grammatical errors